### PR TITLE
Fixing "pandoc: sh: openBinaryFile: does not exist (No such file or directory)" error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,4 @@
-FROM pandoc/latex
-WORKDIR /src
-COPY composer.* ./
-
+FROM pandoc/latex:2.6
 # Install composer, refer: https://github.com/geshan/docker-php-composer-alpine/blob/master/Dockerfile
 RUN apk --update add wget \ 
 		     curl \
@@ -13,13 +10,15 @@ RUN apk --update add wget \
 		     php7-json \
 		     php7-mbstring \
 		     php7-phar \
-             php7-xml \
-			 php7-simplexml \
+                     php7-xml \
+	             php7-simplexml \
 		     php7-dom --repository http://nl.alpinelinux.org/alpine/edge/testing/ && rm /var/cache/apk/*
 
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer 
 # end of install composer
 
+WORKDIR /src
+COPY composer.* ./
 RUN composer install
 COPY . .
-CMD ["sh"]
+ENTRYPOINT ["/bin/sh", "-c"]

--- a/README.md
+++ b/README.md
@@ -46,13 +46,13 @@ You can set `indexes` as `true` if you want pages with the same name as a direct
 `php convert.php --filename=mediawiki.xml --output=export --indexes=true`
 
 ####--frontmatter####
-You can specify whether you want frontmatter included. This is automatically set to `true` when the output format is `markdown_github`
+You can specify whether you want frontmatter included. This is automatically set to `true` when the output format is `gfm`
 
 `php convert.php --filename=mediawiki.xml --output=export --format=markdown_phpextra --frontmatter=true`
 
 
 ####--format####
-You can specify different output formats with `format`. The default is `markdown_github`. See 
+You can specify different output formats with `format`. The default is `gfm`. See 
 
 `php convert.php --filename=mediawiki.xml --output=export --format=markdown_phpextra`
 
@@ -76,7 +76,7 @@ Supported pandoc formats are:
 * latex
 * man
 * markdown
-* markdown_github
+* gfm
 * markdown_mmd
 * markdown_phpextra
 * markdown_strict

--- a/convert.php
+++ b/convert.php
@@ -29,11 +29,11 @@ if(!empty($arguments['output'])) {
 if(!empty($arguments['format'])) {
     $format = $arguments['format'];
 } else {
-    $format = 'markdown_github';
+    $format = 'gfm';
 }
 
 
-if(!empty($arguments['fm']) OR (empty($arguments['fm']) && $format == 'markdown_github')) {
+if(!empty($arguments['fm']) OR (empty($arguments['fm']) && $format == 'gfm')) {
     $add_meta = true;
 } else {
     $add_meta = false;

--- a/convert.ps1
+++ b/convert.ps1
@@ -37,4 +37,4 @@ docker build -t $image .
 
 RefreshDirectory $outputFolder
 $dockerRunCmd = "php convert.php --filename="+$fileToConvertPathForDockerImage+" --output=./output"
-docker run -v ${PSScriptRoot}/output/:/src/output $image sh -c $dockerRunCmd
+docker run -v ${PSScriptRoot}/output/:/src/output $image $dockerRunCmd


### PR DESCRIPTION
as of today,  pandoc/latex image is using version 2.6 and casing error "pandoc: sh: openBinaryFile: does not exist (No such file or directory)" this is due to changes made to entrypoint.
The fixes makes the image work again